### PR TITLE
Flag lager messages coming from error_logger in message metadata

### DIFF
--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -47,7 +47,8 @@
 -define(LOGMSG(Level, Pid, Msg),
     case ?SHOULD_LOG(Level) of
         true ->
-            _ =lager:log(Level, Pid, "[ELLH] " ++ Msg),
+            Metadata = [{pid, Pid}, {error_logger, true}],
+            _ =lager:log(Level, Pid, Msg),
             ok;
         _ -> ok
     end).
@@ -55,7 +56,8 @@
 -define(LOGFMT(Level, Pid, Fmt, Args),
     case ?SHOULD_LOG(Level) of
         true ->
-            _ = lager:log(Level, Pid, "[ELLH] " ++ Fmt, Args),
+            Metadata = [{pid, Pid}, {error_logger, true}],
+            _ = lager:log(Level, Metadata, Fmt, Args),
             ok;
         _ -> ok
     end).

--- a/src/error_logger_lager_h.erl
+++ b/src/error_logger_lager_h.erl
@@ -47,7 +47,7 @@
 -define(LOGMSG(Level, Pid, Msg),
     case ?SHOULD_LOG(Level) of
         true ->
-            _ =lager:log(Level, Pid, Msg),
+            _ =lager:log(Level, Pid, "[ELLH] " ++ Msg),
             ok;
         _ -> ok
     end).
@@ -55,7 +55,7 @@
 -define(LOGFMT(Level, Pid, Fmt, Args),
     case ?SHOULD_LOG(Level) of
         true ->
-            _ = lager:log(Level, Pid, Fmt, Args),
+            _ = lager:log(Level, Pid, "[ELLH] " ++ Fmt, Args),
             ok;
         _ -> ok
     end).


### PR DESCRIPTION
Simple hack to solve an ugly problem.

Problem:
error_logger sends messages to all registered handlers.
lager and raven both attach error_logger handlers.
lager also publishes messages to raven, since we run raven_lager_backend.

So an error report from error_logger will be captured in sentry by raven twice: once from error_logger itself to raven_error_logger module, the second from lager to raven_lager_backend module.

To avoid this, patch error_logger_lager_h to include {error_logger, true} in message metadata, which raven_error_logger can use to filter out such redundant messages.

Lager metadata is normally only used for pids, but accepts any proplist entries: https://github.com/ptuckey/lager/blob/master/src/lager.erl#L131-L134
